### PR TITLE
refactor: 진단 도구 상태 enum으로 변경 및 eventCode 자동 계산 로직 도입

### DIFF
--- a/src/main/java/check/demo/dto/HealthMetricEventDto.java
+++ b/src/main/java/check/demo/dto/HealthMetricEventDto.java
@@ -8,8 +8,8 @@ import java.time.LocalDateTime;
 public class HealthMetricEventDto {
     private Long cctvId;
     private LocalDateTime timestamp;
-    private boolean icmpStatus;
-    private boolean hlsStatus;
+    private String icmpStatusEnum;  // "OK", "TIMEOUT", "FAILED"
+    private String ffprobeStatusEnum;  // "OK", "TIMEOUT", "ERROR", "PORT_UNREACHABLE"
     private String eventCode;
 
     private Double icmpAvgRttMs;

--- a/src/main/java/check/demo/model/FFProbeResult.java
+++ b/src/main/java/check/demo/model/FFProbeResult.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FFProbeResult {
     public enum Status {
-        OK, TIMEOUT, ERROR, PORT_UNREACHABLE
+        OK, TIMEOUT, ERROR, PORT_UNREACHABLE, UNDEFINED
     }
 
     private final Status status;

--- a/src/main/java/check/demo/model/IcmpResult.java
+++ b/src/main/java/check/demo/model/IcmpResult.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class IcmpResult {
     public enum Status {
-        OK, TIMEOUT, FAILED
+        OK, TIMEOUT, FAILED, UNDEFINED
     }
 
     private final Status status;

--- a/src/main/java/check/demo/model/metrics/HealthMetric.java
+++ b/src/main/java/check/demo/model/metrics/HealthMetric.java
@@ -18,9 +18,9 @@ public class HealthMetric {
 
     private Long cctvId;
     private LocalDateTime eventTimestamp;
-    private boolean icmpStatus;
-    private boolean hlsStatus;
-    private String eventCode;
+    private String icmpStatusEnum;  // "OK", "TIMEOUT", "FAILED"
+    private String ffprobeStatusEnum;  // "OK", "TIMEOUT", "ERROR", "PORT_UNREACHABLE"
+    private String eventCode;  // 초기 상태 코드 (예: "ICMP_FAILED", "HLS_TIMEOUT")
 
     private Double icmpAvgRttMs;      // RTT 평균 (ms)
     private Double icmpPacketLossPct; // 패킷 손실률 (%)

--- a/src/main/java/check/demo/service/FFProbeUtil.java
+++ b/src/main/java/check/demo/service/FFProbeUtil.java
@@ -17,6 +17,12 @@ import java.util.stream.Collectors;
 public class FFProbeUtil {
 
     public static FFProbeResult runFFProbe(String rtspUrl) {
+        // 입력값 검증
+        if (rtspUrl == null || rtspUrl.trim().isEmpty() || !rtspUrl.startsWith("rtsp://")) {
+            log.warn("Invalid RTSP URL: {}", rtspUrl);
+            return new FFProbeResult(FFProbeResult.Status.UNDEFINED, "Invalid RTSP URL", "");
+        }
+
         List<String> command = new ArrayList<>(List.of(
                 "ffprobe",
                 "-v", "error",

--- a/src/main/java/check/demo/service/HealthCheckService.java
+++ b/src/main/java/check/demo/service/HealthCheckService.java
@@ -35,6 +35,8 @@ public class HealthCheckService {
     private final HealthMetricRepository repository;
     private final IcmpChecker icmpChecker;
 
+    private static final double HIGH_RTT_THRESHOLD_MS = 200.0; // 고 RTT 기준 (ms)
+
     @Async
     @Transactional("metricsTx") // 메트릭 DB 트랜잭션
     public void check(Long cctvId, String ip) {
@@ -42,59 +44,96 @@ public class HealthCheckService {
         log.info("rtsp://{}:*****@{}:{}{}", username, ip, port, path);
 
         IcmpResult icmp = icmpChecker.check(ip);
-        FFProbeResult result = runFFProbe(rtspUrl);
+        FFProbeResult ffprobe = runFFProbe(rtspUrl);
 
         HealthMetric metric = new HealthMetric();
         metric.setCctvId(cctvId);
         metric.setEventTimestamp(LocalDateTime.now());
 
-        // ICMP 상태 처리
-        switch (icmp.getStatus()) {
-            case FAILED -> {
-                metric.setIcmpStatus(false);
-                metric.setEventCode("ICMP_FAILED");
-                metric.setIcmpAvgRttMs(null);
-                metric.setIcmpPacketLossPct(null);
-            }
-            case TIMEOUT -> {
-                metric.setIcmpStatus(false);
-                metric.setEventCode("ICMP_TIMEOUT");
-                metric.setIcmpAvgRttMs(icmp.getAvgRttMs());
-                metric.setIcmpPacketLossPct(icmp.getPacketLossPct());
-            }
-            case OK -> {
-                metric.setIcmpStatus(true);
-                if (icmp.getPacketLossPct() != null && icmp.getPacketLossPct() > 0) {
-                    metric.setEventCode("ICMP_LOSS");
-                } else {
-                    metric.setEventCode("ICMP_OK");
-                }
-                metric.setIcmpAvgRttMs(icmp.getAvgRttMs());
-                metric.setIcmpPacketLossPct(icmp.getPacketLossPct());
-            }
-        }
+        metric.setIcmpStatusEnum(icmp.getStatus().name());
+        metric.setFfprobeStatusEnum(ffprobe.getStatus().name());
+        metric.setIcmpAvgRttMs(icmp.getAvgRttMs());
+        metric.setIcmpPacketLossPct(icmp.getPacketLossPct());
 
-        // RTSP(HLS) 상태 처리
-        switch (result.getStatus()) {
-            case OK -> {
-                metric.setHlsStatus(true);
-                metric.setEventCode(icmp.isSuccess() ? "HLS_OK" : "ICMP_FAIL");
-            }
-            case TIMEOUT -> {
-                metric.setHlsStatus(false);
-                metric.setEventCode("HLS_TIMEOUT");
-            }
-            case ERROR -> {
-                metric.setHlsStatus(false);
-                metric.setEventCode("HLS_ERROR");
-            }
-            case PORT_UNREACHABLE -> {
-                metric.setHlsStatus(false);
-                metric.setEventCode("RTSP_PORT_FAIL");
-            }
-        }
+        // eventCode 계산
+        String eventCode = calculateEventCode(icmp, ffprobe);
+        metric.setEventCode(eventCode);
 
         // 메트릭 DB 저장
         repository.save(metric);
     }
+
+    private String calculateEventCode(IcmpResult icmp, FFProbeResult ffprobe) {
+        // UNDEFINED 상태 체크 (8번 레코드)
+        if (icmp.getStatus() == IcmpResult.Status.UNDEFINED || ffprobe.getStatus() == FFProbeResult.Status.UNDEFINED) {
+            return "UNDEFINED";
+        }
+
+        // ICMP와 FFProbe 모두 OK일 때 (1번 레코드)
+        if (icmp.getStatus() == IcmpResult.Status.OK && ffprobe.getStatus() == FFProbeResult.Status.OK
+                && (icmp.getAvgRttMs() == null || icmp.getAvgRttMs() < HIGH_RTT_THRESHOLD_MS)
+                && (icmp.getPacketLossPct() == null || icmp.getPacketLossPct() == 0)) {
+            return "OK";
+        }
+
+        // ICMP 상태 기반 코드
+        String icmpCode;
+        switch (icmp.getStatus()) {
+            case OK:
+                if (icmp.getAvgRttMs() != null && icmp.getAvgRttMs() >= HIGH_RTT_THRESHOLD_MS) {
+                    icmpCode = "NETWORK_CONGESTION"; // 레코드 4, 5
+                } else if (icmp.getPacketLossPct() != null && icmp.getPacketLossPct() > 0) {
+                    icmpCode = "ICMP_LOSS";
+                } else {
+                    icmpCode = "ICMP_OK";
+                }
+                break;
+            case TIMEOUT:
+                icmpCode = "ICMP_TIMEOUT";
+                break;
+            case FAILED:
+                icmpCode = "ICMP_FAILED";
+                break;
+            default:
+                icmpCode = "UNKNOWN";
+        }
+
+        // FFProbe 상태 기반 코드
+        String ffprobeCode;
+        switch (ffprobe.getStatus()) {
+            case OK:
+                ffprobeCode = "HLS_OK";
+                break;
+            case TIMEOUT:
+                ffprobeCode = "HLS_TIMEOUT"; // 레코드 6
+                break;
+            case ERROR:
+                ffprobeCode = "STREAM_DATA_CORRUPTION"; // 레코드 7
+                break;
+            case PORT_UNREACHABLE:
+                ffprobeCode = "RTSP_PORT_FAIL"; // 레코드 3
+                break;
+            default:
+                ffprobeCode = "UNKNOWN";
+        }
+
+        // 조합 로직 (주어진 테이블 기반)
+        if (icmp.getStatus() == IcmpResult.Status.FAILED && ffprobe.getStatus() == FFProbeResult.Status.PORT_UNREACHABLE) {
+            return "DEVICE_DOWN"; // 레코드 2
+        } else if (icmp.getStatus() == IcmpResult.Status.OK && icmp.getAvgRttMs() != null && icmp.getAvgRttMs() >= HIGH_RTT_THRESHOLD_MS && ffprobe.getStatus() == FFProbeResult.Status.OK) {
+            return "NETWORK_CONGESTION"; // 레코드 4
+        } else if (icmp.getStatus() == IcmpResult.Status.OK && icmp.getAvgRttMs() != null && icmp.getAvgRttMs() >= HIGH_RTT_THRESHOLD_MS && ffprobe.getStatus() == FFProbeResult.Status.ERROR) {
+            return "NETWORK_OVERLOAD"; // 레코드 5
+        } else if (icmp.getStatus() == IcmpResult.Status.OK && ffprobe.getStatus() == FFProbeResult.Status.TIMEOUT) {
+            return "SESSION_OR_RTSP_BUFFER"; // 레코드 6
+        } else if (icmp.getStatus() == IcmpResult.Status.OK && ffprobe.getStatus() == FFProbeResult.Status.ERROR) {
+            return "STREAM_DATA_CORRUPTION"; // 레코드 7
+        } else if (icmp.getStatus() == IcmpResult.Status.OK && ffprobe.getStatus() == FFProbeResult.Status.PORT_UNREACHABLE) {
+            return "RTSP_PORT_FAIL"; // 레코드 3
+        }
+
+        // 기본적으로 FFProbe 우선, 없으면 ICMP 코드
+        return ffprobeCode.equals("HLS_OK") ? icmpCode : ffprobeCode;
+    }
+
 }

--- a/src/main/java/check/demo/service/IcmpChecker.java
+++ b/src/main/java/check/demo/service/IcmpChecker.java
@@ -5,11 +5,17 @@ import org.springframework.stereotype.Component;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Component
 public class IcmpChecker {
 
     public IcmpResult check(String ip) {
+        // 입력값 검증
+        if (ip == null || ip.trim().isEmpty() || !isValidIp(ip)) {
+            return new IcmpResult(IcmpResult.Status.UNDEFINED, false, null, null);
+        }
         try {
             String os = System.getProperty("os.name").toLowerCase();
             ProcessBuilder builder;
@@ -28,18 +34,22 @@ public class IcmpChecker {
             double avgRtt = -1;
             double packetLoss = -1;
 
+            Pattern packetPattern = Pattern.compile("(\\d+)%?\\s*packet loss|패킷.*(\\d+)%");
+            Pattern rttPattern = Pattern.compile("rtt min/avg/max.*=.*\\d+\\.\\d+/(\\d+\\.\\d+)|평균 = (\\d+)ms");
+
             while ((line = reader.readLine()) != null) {
-                if (line.contains("packets transmitted") || line.contains("패킷을 보냈고")) {
-                    String[] parts = line.split(",");
-                    if (parts.length >= 3) {
-                        packetLoss = Double.parseDouble(parts[2].replaceAll("[^0-9.]", ""));
-                    }
-                } else if (line.contains("rtt min/avg/max") || line.contains("평균 =")) {
-                    String[] parts = line.split("=");
-                    if (parts.length >= 2) {
-                        String[] rttParts = parts[1].trim().split("/");
-                        avgRtt = Double.parseDouble(rttParts[1]);
-                    }
+                // 패킷 손실률 파싱
+                Matcher packetMatcher = packetPattern.matcher(line);
+                if (packetMatcher.find()) {
+                    String lossStr = packetMatcher.group(1);
+                    packetLoss = lossStr != null ? Double.parseDouble(lossStr) : null;
+                }
+
+                // RTT 파싱
+                Matcher rttMatcher = rttPattern.matcher(line);
+                if (rttMatcher.find()) {
+                    String rttStr = rttMatcher.group(1) != null ? rttMatcher.group(1) : rttMatcher.group(2);
+                    avgRtt = rttStr != null ? Double.parseDouble(rttStr) : null;
                 }
             }
 
@@ -53,5 +63,10 @@ public class IcmpChecker {
         } catch (Exception e) {
             return new IcmpResult(IcmpResult.Status.FAILED, false, null, null);
         }
+    }
+
+    private boolean isValidIp(String ip) {
+        String ipPattern = "^([0-9]{1,3}\\.){3}[0-9]{1,3}$";
+        return ip != null && ip.matches(ipPattern);
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,10 +1,10 @@
-CREATE TABLE IF NOT EXISTS health_metrics (
-    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    cctv_id BIGINT NULL,
-    event_code VARCHAR(255) NULL,
-    hls_status BOOLEAN NOT NULL,
-    icmp_avg_rtt_ms DOUBLE NULL,
-    icmp_packet_loss_pct DOUBLE NULL,
-    icmp_status BOOLEAN NULL,
-    event_timestamp TIMESTAMP(6) NULL
-);
+--CREATE TABLE IF NOT EXISTS health_metrics (
+--    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+--    cctv_id BIGINT NULL,
+--    event_code VARCHAR(255) NULL,
+--    hls_status BOOLEAN NOT NULL,
+--    icmp_avg_rtt_ms DOUBLE NULL,
+--    icmp_packet_loss_pct DOUBLE NULL,
+--    icmp_status BOOLEAN NULL,
+--    event_timestamp TIMESTAMP(6) NULL
+--);


### PR DESCRIPTION
- ICMP/FFProbe 등 진단 도구 status를 boolean에서 enum 값으로 확장
- 상태 조합별 eventCode를 매핑·자동 계산하여 저장하도록 데이터 모델링 변경
- 상태 매핑(1~8번) 표 추가 및 매핑 로직 구현
- eventCode 계산이 단순한 경우 상태 감지 서비스에서 처리, 추후 복잡해질 경우 Drools 등 규칙 엔진 도입 고려