### PR TITLE
fix: IcmpResult 생성자 인자 순서 오류 수정 및 OS별 패턴 매칭 분리

### DIFF
--- a/src/main/java/check/demo/service/HealthCheckService.java
+++ b/src/main/java/check/demo/service/HealthCheckService.java
@@ -66,6 +66,9 @@ public class HealthCheckService {
     }
 
     private String calculateEventCode(IcmpResult icmp, FFProbeResult ffprobe) {
+        log.info(icmp.toString());
+        log.info(ffprobe.toString());
+
         // UNDEFINED 상태 체크 (8번 레코드)
         if (icmp.getStatus() == IcmpResult.Status.UNDEFINED || ffprobe.getStatus() == FFProbeResult.Status.UNDEFINED) {
             return "UNDEFINED";

--- a/src/main/java/check/demo/service/IcmpChecker.java
+++ b/src/main/java/check/demo/service/IcmpChecker.java
@@ -5,6 +5,7 @@ import check.demo.model.IcmpResult;
 import org.springframework.stereotype.Component;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -33,38 +34,49 @@ public class IcmpChecker {
             Double packetLoss = null;
 
             // Linux 예: "rtt min/avg/max/mdev = 0.041/0.052/0.067/0.010 ms"
-            Pattern linuxRtt  = Pattern.compile("(?:rtt|round-trip) min/avg/max/(?:mdev|stddev) = ([\\d.]+)/([\\d.]+)/([\\d.]+)/");
-            Pattern linuxLoss = Pattern.compile("(\\d+)%\\s*packet loss");
             // Windows(영/한) 예: "Minimum = 10ms, Maximum = 30ms, Average = 20ms" / "최소 = 10ms, 최대 = 30ms, 평균 = 20ms"
-            Pattern winRtt    = Pattern.compile("(?:Minimum|최소)\\s*=\\s*(\\d+)ms,\\s*(?:Maximum|최대)\\s*=\\s*(\\d+)ms,\\s*(?:Average|평균)\\s*=\\s*(\\d+)ms");
-            Pattern winLoss   = Pattern.compile("\\((\\d+)%\\s*(?:loss|손실)\\)");
 
-            while ((line = reader.readLine()) != null) {
-                // 손실률
-                Matcher m1 = linuxLoss.matcher(line);
-                Matcher m2 = winLoss.matcher(line);
-                if (m1.find()) packetLoss = Double.valueOf(m1.group(1));
-                else if (m2.find()) packetLoss = Double.valueOf(m2.group(1));
+            if (os.contains("win")) {
+                Pattern winLossPattern = Pattern.compile("\\((\\d+)%\\s*(?:loss|손실)\\)");
+                Pattern winRttPattern = Pattern.compile("(?:Minimum|최소)\\s*=\\s*(\\d+)ms,\\s*(?:Maximum|최대)\\s*=\\s*(\\d+)ms,\\s*(?:Average|평균)\\s*=\\s*(\\d+)ms");
 
-                // RTT
-                Matcher r1 = linuxRtt.matcher(line);
-                Matcher r2 = winRtt.matcher(line);
-                if (r1.find()) {
-                    rttMin = Double.valueOf(r1.group(1));
-                    rttAvg = Double.valueOf(r1.group(2));
-                    rttMax = Double.valueOf(r1.group(3));
-                } else if (r2.find()) {
-                    rttMin = Double.valueOf(r2.group(1));
-                    rttMax = Double.valueOf(r2.group(2));
-                    rttAvg = Double.valueOf(r2.group(3));
+                while ((line = reader.readLine()) != null) {
+                    Matcher lossMatcher = winLossPattern.matcher(line);
+                    if (lossMatcher.find() && packetLoss == null) {
+                        packetLoss = Double.valueOf(lossMatcher.group(1));
+                    }
+                    Matcher rttMatcher = winRttPattern.matcher(line);
+                    if (rttMatcher.find()) {
+                        rttMin = Double.valueOf(rttMatcher.group(1));
+                        rttMax = Double.valueOf(rttMatcher.group(2));
+                        rttAvg = Double.valueOf(rttMatcher.group(3));
+                    }
+                }
+            } else {
+                Pattern linuxLossPattern = Pattern.compile("(\\d+)%\\s*packet loss");
+                Pattern linuxRttPattern = Pattern.compile(
+                        "(?:rtt|round-trip) min/avg/max/(?:mdev|stddev) = ([\\d.]+)/([\\d.]+)/([\\d.]+)/[\\d.]+ ms"
+                );
+
+                while ((line = reader.readLine()) != null) {
+                    Matcher lossMatcher = linuxLossPattern.matcher(line);
+                    if (lossMatcher.find() && packetLoss == null) {
+                        packetLoss = Double.valueOf(lossMatcher.group(1));
+                    }
+                    Matcher rttMatcher = linuxRttPattern.matcher(line);
+                    if (rttMatcher.find()) {
+                        rttMin = Double.valueOf(rttMatcher.group(1));
+                        rttAvg = Double.valueOf(rttMatcher.group(2));
+                        rttMax = Double.valueOf(rttMatcher.group(3));
+                    }
                 }
             }
 
             int exitCode = process.waitFor();
             if (exitCode != 0) {
-                return new IcmpResult(IcmpResult.Status.TIMEOUT, false, rttAvg, packetLoss, rttMin, rttMax);
+                return new IcmpResult(IcmpResult.Status.TIMEOUT, false, rttAvg, rttMin, rttMax, packetLoss);
             }
-            return new IcmpResult(IcmpResult.Status.OK, true, rttAvg, packetLoss, rttMin, rttMax);
+            return new IcmpResult(IcmpResult.Status.OK, true, rttAvg, rttMin, rttMax, packetLoss);
 
         } catch (Exception e) {
             return new IcmpResult(IcmpResult.Status.FAILED, false, null, null, null, null);


### PR DESCRIPTION
- IcmpResult 생성자에 잘못 전달되던 인자 순서를 수정
- OS별 ping 결과 파싱을 if/else 구문으로 명확히 분리
- 출력 라인 버퍼 종속성 문제는 추후 개선 예정

Closes #24